### PR TITLE
[CMSP-150] Update network setup (#49)

### DIFF
--- a/inc/network/includes-network.php
+++ b/inc/network/includes-network.php
@@ -438,7 +438,7 @@ function network_step2( $errors = false ) {
 		<?php
 		printf(
 			/* translators: 1: wp-config.php, 2: Location of wp-config file, 3: Translated version of "That's all, stop editing! Happy publishing." */
-			esc_html__( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ),
+			wp_kses_post( __( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ) ),
 			'<code>' . $config_filename . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'<code>' . $location_of_wp_config . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			// translators: This string should only be translated if wp-config-sample.php is localized.
@@ -456,8 +456,8 @@ function network_step2( $errors = false ) {
 			);
 			?>
 		</label></p>
-		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="31" aria-describedby="network-wpconfig-rules-description">
-	<?php ob_start(); ?>
+		<textarea id="network-wpconfig-rules" class="code" readonly="readonly" cols="100" rows="8" aria-describedby="network-wpconfig-rules-description">
+<?php ob_start(); // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
 // Use PANTHEON_HOSTNAME if in a Pantheon environment, otherwise use HTTP_HOST.

--- a/pantheon.php
+++ b/pantheon.php
@@ -3,14 +3,14 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 1.4.3
+ * Version: 1.4.4
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
  * @package pantheon
  */
 
-define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.3' );
+define( 'PANTHEON_MU_PLUGIN_VERSION', '1.4.4' );
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	require_once 'inc/functions.php';
@@ -46,9 +46,8 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'WP_ALLOW_MULTISITE', true );
 	}
 	if ( defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE ) {
-		if ( defined( 'MULTISITE' ) && MULTISITE ) {
-			require_once 'inc/pantheon-network-setup.php';
-		} else {
+		require_once 'inc/pantheon-network-setup.php';
+		if ( ! defined( 'MULTISITE' ) && MULTISITE ) {
 			require_once 'inc/pantheon-multisite-finalize.php';
 		}
 	}


### PR DESCRIPTION
Updates your fork with current `main`.

-----------

* always require the network setup if allow multisite is true this is what replaces the default wp core network page with our own

* remove tab before ob_start this indents the first line in the textarea which we don't want

* reduce the number of lines in the textarea since our instructions are much shorter
in the future maybe we might want this to be filterable but I don't think we need it now

* use wp_kses_post instead of esc_html so we don't escape the html we're legitimately passing

* ignore the lint warning about indentation

* bump version to 1.4.4